### PR TITLE
Fix typos and clean HTML in resume page

### DIFF
--- a/cc/v2019.html
+++ b/cc/v2019.html
@@ -60,7 +60,6 @@
   <div class="col-lg-8 col-md-12">
 
   <h1>Resume</h1>
-  <p>
   <h2>Current role</h2>
 
   <div class="row">
@@ -243,7 +242,7 @@
           2020
         </div>
         <div class="col-9">
-          CS50x Introduction to Computer Science, <a href="https://cs50.harvard.edu/x/2020/">Hardvard X</a>
+          CS50x Introduction to Computer Science, <a href="https://cs50.harvard.edu/x/2020/">HarvardX</a>
         </div>
       </div>
       <div class="row">


### PR DESCRIPTION
## Summary
- remove orphan `<p>` tag in `v2019.html`
- fix Harvard name typo

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68407ac2ca1c832782b82c0c56ce1c6f